### PR TITLE
Only apply changes to cameras if something actually changed

### DIFF
--- a/Assets/TButt/Scripts/Camera/TBCameraRig.cs
+++ b/Assets/TButt/Scripts/Camera/TBCameraRig.cs
@@ -299,13 +299,27 @@ namespace TButt
 
         private void SyncCameraSettings(Camera cam)
         {
-            cam.clearFlags = clearFlags;
-            cam.cullingMask = cullingMask;
-            cam.nearClipPlane = nearClipPlane;
-            cam.farClipPlane = farClipPlane;
-            cam.backgroundColor = backgroundColor;
-            cam.useOcclusionCulling = useOcclusionCulling;
-            cam.opaqueSortMode = sortMode;
+            if(cam.clearFlags != clearFlags) { 
+                cam.clearFlags = clearFlags;
+            }
+            if(cam.cullingMask != cullingMask) {
+                cam.cullingMask = cullingMask;
+            }
+            if(cam.nearClipPlane != nearClipPlane) {
+                cam.nearClipPlane = nearClipPlane;
+            }
+            if(cam.farClipPlane != farClipPlane) {
+                cam.farClipPlane = farClipPlane;
+            }
+            if(cam.backgroundColor != backgroundColor) {
+                cam.backgroundColor = backgroundColor;
+            }
+            if(cam.useOcclusionCulling != useOcclusionCulling) {
+                cam.useOcclusionCulling = useOcclusionCulling;
+            }
+            if(cam.opaqueSortMode != sortMode) {
+                cam.opaqueSortMode = sortMode;
+            }
         }
 
         public Transform GetTBCenter()


### PR DESCRIPTION
When using TBCameraRig together with VCS that automatically checks out assets based on saving rather than actual changes, e.g. Perforce plugin in Unity, TBCameraRig.prefab is considered dirty and checked out after each CTRL+S. My initial testing seems to point towards this change solving that.